### PR TITLE
Display all batteries that upower knows about

### DIFF
--- a/scripts/battery_icon.sh
+++ b/scripts/battery_icon.sh
@@ -36,8 +36,10 @@ battery_status() {
 	if command_exists "pmset"; then
 		pmset -g batt | awk -F '; *' 'NR==2 { print $2 }'
 	elif command_exists "upower"; then
-		battery=$(upower -e | grep battery | head -1)
-		upower -i $battery | grep state | awk '{print $2}'
+		# sort order: attached, charging, discharging
+		for battery in $(upower -e | grep battery); do
+			upower -i $battery | grep state | awk '{print $2}'
+		done | sort | head -1
 	fi
 }
 

--- a/scripts/battery_percentage.sh
+++ b/scripts/battery_percentage.sh
@@ -9,8 +9,9 @@ print_battery_percentage() {
 	if command_exists "pmset"; then
 		pmset -g batt | awk 'NR==2 { gsub(/;/,""); print $2 }'
 	elif command_exists "upower"; then
-		battery=$(upower -e | grep battery | head -1)
-		upower -i $battery | grep percentage | awk '{print $2}'
+		for battery in $(upower -e | grep battery); do
+			upower -i $battery | grep percentage | awk '{print $2}'
+		done | xargs echo
 	fi
 }
 


### PR DESCRIPTION
My laptop has two batteries: One exchangeable and a built-in one. The exchangeable battery will unload before the internal. Unfortunately `BAT0` is the internal battery and `BAT1` is the external one. Without this patch, `battery_percentage.sh` displays 100% until the exchangeable battery ran out of power. 

I'm suggesting to display all batteries that `upower` knows about. With this patch all batteries percentage levels will be displayed with a seperating space: "14% 85%".

If there is only one battery, the behavior of this script does not change. The for-loop will yield exactly one line and `xargs echo` won't change it.

I tested this on my system by pretending what would happen if it had only one battery.
```
for battery in $(upower -e | grep battery | head -1); do \
  upower -i $battery | grep percentage | awk '{print $2}'; \
done | xargs echo
```

This is how the `upower -e` output looks on my machine:

```
$ upower -e
/org/freedesktop/UPower/devices/line_power_AC
/org/freedesktop/UPower/devices/battery_BAT0
/org/freedesktop/UPower/devices/battery_BAT1
```