### PR TITLE
Optional highlight for battery level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - display all batteries that upower knows about (@JanAhrens)
 - acpi battery status (@cpb)
 - fix issue with status-right and status-left whitespace being cut out
+- Added possibility to highlight percentage if threshold is reached
 
 ### v1.1.0, 2015-03-14
 - change the default icon for "attached" battery state from :snail: to :warning:

--- a/scripts/battery_percentage.sh
+++ b/scripts/battery_percentage.sh
@@ -18,6 +18,12 @@ print_battery_percentage() {
 }
 
 main() {
-	print_battery_percentage
+	hlevel=$(get_tmux_option "@batt_highlightlevel" "0")
+	hcolor="default"
+	if [[ `print_battery_percentage | sed -e 's/%//g'` -lt $hlevel ]];then
+		hcolor=$(get_tmux_option "@batt_highlightcolor" "default")
+	fi
+	value=$(print_battery_percentage)
+	echo "#[fg=$hcolor]$value#[fg=default]"
 }
 main


### PR DESCRIPTION
Add the possibility to define a level and color the battery percentage is highlighted, if the current value is below.