### PR TITLE
Don't modify line endings of screenshot images

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 # Force text files to have unix eols, so Windows/Cygwin does not break them
-*.* eol=lf
+*.*   eol=lf
+*.png -text


### PR DESCRIPTION
I have this plugin installed as a git submodule, and ever since 41c90a2 my git client complains about this submodule having unstaged changes due to the line endings of these images.