### PR TITLE
Close #20. When pmset, find percentage using regex

### DIFF
--- a/scripts/battery_percentage.sh
+++ b/scripts/battery_percentage.sh
@@ -7,7 +7,7 @@ source "$CURRENT_DIR/helpers.sh"
 print_battery_percentage() {
 	# percentage displayed in the 2nd field of the 2nd row
 	if command_exists "pmset"; then
-		pmset -g batt | awk 'NR==2 { gsub(/;/,""); print $2 }'
+		pmset -g batt | perl -n -e'/(\d+%)/ && print $1'
 	elif command_exists "upower"; then
 		for battery in $(upower -e | grep battery); do
 			upower -i $battery | grep percentage | awk '{print $2}'


### PR DESCRIPTION
Tested in El Capitan and macOS Sierra Beta 2.

El Capitan:

```
Now drawing from 'Battery Power'
 -InternalBattery-0     85%; discharging; 2:02 remaining present: true
```

Sierra Beta 2:

```
Now drawing from 'AC Power'
  -InternalBattery-0 (id=4063331)    67%; charging; 1:31 remaining present: true
```

I don't know if Mac adds the ID for preview versions, and then removes
it, but this patch should work as long as the output contains only one
percentage.