### PR TITLE
add support for UPower version 0.99.4

### DIFF
--- a/scripts/battery_remain.sh
+++ b/scripts/battery_remain.sh
@@ -22,7 +22,7 @@ print_battery_remain() {
 		pmset_battery_remaining_time
 	elif command_exists "upower"; then
 		battery=$(upower -e | grep battery | head -1)
-		upower -i $battery | grep remain | awk '{print $4}'
+		upower -i $battery | grep -E '(remain|time to empty)' | awk '{print $(NF-1)}'
 	elif command_exists "acpi"; then
 		acpi -b | grep -Eo "[0-9]+:[0-9]+:[0-9]+"
 	fi


### PR DESCRIPTION
A quick solution, need to ensure there is no regression as I don't know the format of the `grep remain` case.

`upower` output for reference:

```
$ upower -i /org/freedesktop/UPower/devices/battery_BAT0
  native-path:          BAT0
  vendor:               LGC
  model:                00HW002
  serial:               2598
  power supply:         yes
  updated:              Tue 06 Sep 2016 04:14:53 PM CEST (12 seconds ago)
  has history:          yes
  has statistics:       yes
  battery
    present:             yes
    rechargeable:        yes
    state:               discharging
    warning-level:       none
    energy:              44,67 Wh
    energy-empty:        0 Wh
    energy-full:         46,97 Wh
    energy-full-design:  50,22 Wh
    energy-rate:         12,546 W
    voltage:             16,728 V
    time to empty:       3,6 hours  # <--------------------------------------------
    percentage:          95%
    capacity:            93,2099%
    technology:          lithium-polymer
    icon-name:          'battery-full-symbolic'
  History (charge):
    1473171293  95,000  discharging
  History (rate):
    1473171293  12,546  discharging
```
