### PR TITLE
Fixed charged percentage and remaining time.

### DIFF
--- a/scripts/battery_percentage.sh
+++ b/scripts/battery_percentage.sh
@@ -7,7 +7,7 @@ source "$CURRENT_DIR/helpers.sh"
 print_battery_percentage() {
 	# percentage displayed in the 2nd field of the 2nd row
 	if command_exists "pmset"; then
-		pmset -g batt | awk 'NR==2 { gsub(/;/,""); print $2 }'
+		pmset -g batt | awk 'NR==2 { gsub(/;/,""); print $3 }'
 	elif command_exists "upower"; then
 		for battery in $(upower -e | grep battery); do
 			upower -i $battery | grep percentage | awk '{print $2}'

--- a/scripts/battery_remain.sh
+++ b/scripts/battery_remain.sh
@@ -10,7 +10,7 @@ battery_discharging() {
 }
 
 pmset_battery_remaining_time() {
-	local output="$(pmset -g batt | awk 'NR==2 { gsub(/;/,""); print $4 }')"
+	local output="$(pmset -g batt | awk 'NR==2 { gsub(/;/,""); print $5 }')"
 	# output has to match format "10:42"
 	if [[ "$output" =~ ([[:digit:]]{1,2}:[[:digit:]]{2}) ]]; then
 		printf "$output"


### PR DESCRIPTION
The `awk` command was not correct. At both occurrences, I saw that the element before the actual needed value was retrieved. Fixed it by changing both values.

This fix was needed for my macOS Sierra version 10.12 Beta (16A313a).