### PR TITLE
Fix multi-battery output with upower

### DIFF
--- a/scripts/battery_percentage.sh
+++ b/scripts/battery_percentage.sh
@@ -9,9 +9,14 @@ print_battery_percentage() {
 	if command_exists "pmset"; then
 		pmset -g batt | grep -o "[0-9]\{1,3\}%"
 	elif command_exists "upower"; then
-		for battery in $(upower -e | grep battery); do
-			upower -i $battery | grep percentage | awk '{print $2}'
-		done | xargs echo
+		local batteries=( $(upower -e | grep battery) )
+		local energy
+		local energy_full
+		for battery in ${batteries[@]}; do
+			energy=$(upower -i $battery | awk -v nrg="$energy" '/energy:/ {print nrg+$2}')
+			energy_full=$(upower -i $battery | awk -v nrgfull="$energy_full" '/energy-full:/ {print nrgfull+$2}')
+		done
+		echo $energy $energy_full | awk '{printf("%d%%", ($1/$2)*100)}'
 	elif command_exists "acpi"; then
 		acpi -b | grep -Eo "[0-9]+%"
 	fi


### PR DESCRIPTION
Given multiple batteries in a machine, we will combine the energy and
energy-full values from each battery, then divide the total energy by
the total energy-full, and multiple by 100 to get a percentage. We use
awk to avoid introducing new dependencies, and to also handle the
floating point arithmetic and eventual truncation. This code will always
round your current percentage down.