### PR TITLE
only show status when AC is offline

### DIFF
--- a/scripts/battery_graph.sh
+++ b/scripts/battery_graph.sh
@@ -21,6 +21,7 @@ print_graph() {
 }
 
 main() {
+	ac_online && { echo ""; return 0; }
 	local percentage=$($CURRENT_DIR/battery_percentage.sh)
 	print_graph ${percentage%?}
 }

--- a/scripts/battery_icon.sh
+++ b/scripts/battery_icon.sh
@@ -46,6 +46,8 @@ print_icon() {
 }
 
 main() {
+	ac_online && { echo ""; return 0; }
+
 	get_icon_settings
 	local status=$(battery_status)
 	print_icon "$status"

--- a/scripts/battery_percentage.sh
+++ b/scripts/battery_percentage.sh
@@ -9,7 +9,7 @@ print_battery_percentage() {
 	if command_exists "pmset"; then
 		pmset -g batt | grep -o "[0-9]\{1,3\}%"
 	elif command_exists "upower"; then
-		local batteries=( $(upower -e | grep battery) )
+		local batteries=( $(upower -e | grep BAT) )
 		local energy
 		local energy_full
 		for battery in ${batteries[@]}; do

--- a/scripts/battery_percentage.sh
+++ b/scripts/battery_percentage.sh
@@ -23,6 +23,7 @@ print_battery_percentage() {
 }
 
 main() {
+	ac_online && { echo ""; return 0; }
 	print_battery_percentage
 }
 main

--- a/scripts/battery_remain.sh
+++ b/scripts/battery_remain.sh
@@ -20,12 +20,12 @@ print_battery_remain() {
 		battery=$(upower -e | grep battery | head -1)
 		if is_chrome; then
 			if battery_discharging; then
-				upower -i $battery | grep 'time to empty' | awk '{printf "- %s %s left", $4, $5}'
+				upower -i "$battery" | grep 'time to empty' | awk '{printf "- %s %s left", $4, $5}'
 			else
-				upower -i $battery | grep 'time to full' | awk '{printf "- %s %s till full", $4, $5}'
+				upower -i "$battery" | grep 'time to full' | awk '{printf "- %s %s till full", $4, $5}'
 			fi
 		else
-			upower -i $battery | grep -E '(remain|time to empty)' | awk '{print $(NF-1)}'
+			upower -i "$battery" | grep -E '(remain|time to empty)' | awk '{print $(NF-1)}'
 		fi
 	elif command_exists "acpi"; then
 		acpi -b | grep -Eo "[0-9]+:[0-9]+:[0-9]+"
@@ -35,11 +35,13 @@ print_battery_remain() {
 print_battery_full() {
 	if command_exists "upower"; then
 		battery=$(upower -e | grep battery | head -1)
-		upower -i $battery | grep 'time to full' | awk '{printf "- %s %s till full", $4, $5}'
+		upower -i "$battery" | grep 'time to full' | awk '{printf "- %s %s till full", $4, $5}'
 	fi
 }
 
 main() {
+	ac_online && { echo ""; return 0; }
+
 	if battery_discharging; then
 		print_battery_remain
 	else

--- a/scripts/battery_status_bg.sh
+++ b/scripts/battery_status_bg.sh
@@ -15,28 +15,30 @@ color_medium_charge=""
 color_low_charge=""
 
 get_charge_color_settings() {
-    color_full_charge=$(get_tmux_option "@batt_color_full_charge" "$color_full_charge_default")
-    color_high_charge=$(get_tmux_option "@batt_color_high_charge" "$color_high_charge_default")
-    color_medium_charge=$(get_tmux_option "@batt_color_medium_charge" "$color_medium_charge_default")
-    color_low_charge=$(get_tmux_option "@batt_color_low_charge" "$color_low_charge_default")
+	color_full_charge=$(get_tmux_option "@batt_color_full_charge" "$color_full_charge_default")
+	color_high_charge=$(get_tmux_option "@batt_color_high_charge" "$color_high_charge_default")
+	color_medium_charge=$(get_tmux_option "@batt_color_medium_charge" "$color_medium_charge_default")
+	color_low_charge=$(get_tmux_option "@batt_color_low_charge" "$color_low_charge_default")
 }
 
 print_battery_status_bg() {
-    # Call `battery_percentage.sh`.
-    percentage=$($CURRENT_DIR/battery_percentage.sh | sed -e 's/%//')
-    if [ $percentage -eq 100 ]; then
-        printf $color_full_charge
-    elif [ $percentage -le 99 -a $percentage -ge 51 ];then
-        printf $color_high_charge
-    elif [ $percentage -le 50 -a $percentage -ge 16 ];then
-        printf $color_medium_charge
-    else
-        printf $color_low_charge
-    fi
+	# Call `battery_percentage.sh`.
+	percentage=$("$CURRENT_DIR/battery_percentage.sh" | sed -e 's/%//')
+	if [[ "$percentage" -eq 100 ]]; then
+		printf "%s" "$color_full_charge"
+	elif [[ "$percentage" -le 99 && "$percentage" -ge 51 ]]; then
+		printf "%s" "$color_high_charge"
+	elif [[ "$percentage" -le 50 && "$percentage" -ge 16 ]]; then
+		printf "%s" "$color_medium_charge"
+	else
+		printf "%s" "$color_low_charge"
+	fi
 }
 
 main() {
-    get_charge_color_settings
+	ac_online && { echo ""; return 0; }
+
+	get_charge_color_settings
 	print_battery_status_bg
 }
 main

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -10,7 +10,7 @@ get_tmux_option() {
 }
 
 is_osx() {
-	[ $(uname) == "Darwin" ]
+	[[ "$(uname)" == "Darwin" ]]
 }
 
 is_chrome() {
@@ -33,9 +33,26 @@ battery_status() {
 	elif command_exists "upower"; then
 		# sort order: attached, charging, discharging
 		for battery in $(upower -e | grep battery); do
-			upower -i $battery | grep state | awk '{print $2}'
+			upower -i "$battery" | grep state | awk '{print $2}'
 		done | sort | head -1
 	elif command_exists "acpi"; then
 		acpi -b | grep -oi 'discharging' | awk '{print tolower($0)}'
+	fi
+}
+
+ac_online() {
+	local toggle_plug_status="$(get_tmux_option "@batt_toggle_plug_status" "false")"
+	[[ "${toggle_plug_status}" == "false" ]] && return 1
+
+	if command_exists "upower"; then
+		[[ "$(upower -i /org/freedesktop/UPower/devices/line_power_AC | awk -F: '/online/ {gsub(/ /, "", $NF); print $NF}')" == "yes" ]]
+	elif command_exists "acpi"; then
+		acpi -a | grep -q 'on-line'
+	elif command_exists "pmset"; then
+		pmset -g batt | egrep -q "^Now draining from.*AC Power"
+	elif [[ -e /sys/class/power_supply/AC/online ]]; then
+		[[ "$(cat /sys/class/power_supply/AC/online)" -eq 1 ]]
+	else
+		return 0
 	fi
 }


### PR DESCRIPTION
Hey,

I wanted the possibility to only show battery status when the AC is offline. I made it configurable with `@batt_toggle_ac_status`, if not set it will be set to false and it would always show the battery status (how it works now).

This is done with the helper method `ac_online`, if it returns true (0) all the prefixes will return an empty string (not showing anything in the status bar), if it returns false (1) it will show the information.

I only had possibility to test on Ubuntu (with upower and checking sysfs). So `ac_online` should be updated with the results of using `pmset` or `acpi` as well.

Also, I fixed a bunch of shellcheck warnings.

Thanks for a great plugin!