### PR TITLE
Add @batt_remain_short variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,15 @@ after you do this.
 
 *Warning*: The battery icon change most likely will not be instant. When you un-plug the power cord, it will take some time (15 - 60 seconds) for the icon to change. This depends on the `status-interval` tmux option. Setting it to 15 seconds should be good enough.
 
+## Shortened remaining output
+
+To shorten the output of `#{battery_remain}`, set the following variable:
+
+    set -g @batt_remain_short true
+
+This will hide output if the battery is charging or charged, and shorten the
+time remaining (when discharging) to `~H:MM`.
+
 ### Tmux Plugins
 
 This plugin is part of the [tmux-plugins](https://github.com/tmux-plugins) organisation. Checkout plugins as [resurrect](https://github.com/tmux-plugins/tmux-resurrect), [logging](https://github.com/tmux-plugins/tmux-logging), [online status](https://github.com/tmux-plugins/tmux-online-status), and many more over at the [tmux-plugins](https://github.com/tmux-plugins) organisation page.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Battery between 50% and 16% charged:<br/>
 Battery between 15% and dead:<br/>
 ![battery_status_bg_red](/screenshots/battery_status_bg_red.png)
 
-This is done by introducing 4 new format strings that can be added to
+This is done by introducing new format strings that can be added to
 `status-right` option:
 - `#{battery_icon}` - will display a battery status icon
 - `#{battery_percentage}` - will show battery percentage


### PR DESCRIPTION
This adds a variable to shorten the output of `#{batt_remain}`.

When the battery is charging or charged, the output is hidden.

While discharging, the output becomes `~H:MM`.