### PR TITLE
Fix multiple batteries on linux

### DIFF
--- a/scripts/battery_percentage.sh
+++ b/scripts/battery_percentage.sh
@@ -9,19 +9,19 @@ print_battery_percentage() {
 	if command_exists "pmset"; then
 		pmset -g batt | grep -o "[0-9]\{1,3\}%"
 	elif command_exists "upower"; then
-		local batteries=( $(upower -e | grep battery) )
-		if [ -z "$batteries" ]; then
+		local battery=$(upower -e | grep -m 1 battery)
+		if [ -z "$battery" ]; then
 			return
 		fi
 		local energy
 		local energy_full
-		for battery in ${batteries[@]}; do
-			energy=$(upower -i $battery | awk -v nrg="$energy" '/energy:/ {print nrg+$2}')
-			energy_full=$(upower -i $battery | awk -v nrgfull="$energy_full" '/energy-full:/ {print nrgfull+$2}')
-		done
-		echo $energy $energy_full | awk '{printf("%d%%", ($1/$2)*100)}'
+		energy=$(upower -i $battery | awk -v nrg="$energy" '/energy:/ {print nrg+$2}')
+		energy_full=$(upower -i $battery | awk -v nrgfull="$energy_full" '/energy-full:/ {print nrgfull+$2}')
+		if [ -n "$energy" ] && [ -n "$energy_full" ]; then
+			echo $energy $energy_full | awk '{printf("%d%%", ($1/$2)*100)}'
+		fi
 	elif command_exists "acpi"; then
-		acpi -b | grep -Eo "[0-9]+%"
+		acpi -b | grep -m 1 -Eo "[0-9]+%"
 	fi
 }
 

--- a/scripts/battery_remain.sh
+++ b/scripts/battery_remain.sh
@@ -43,7 +43,7 @@ print_battery_remain() {
 	if command_exists "pmset"; then
 		pmset_battery_remaining_time
 	elif command_exists "upower"; then
-		battery=$(upower -e | grep battery | head -1)
+		battery=$(upower -e | grep -m 1 battery)
 		if is_chrome; then
 			if battery_discharging; then
 				upower -i $battery | grep 'time to empty' | awk '{printf "- %s %s left", $4, $5}'
@@ -54,7 +54,7 @@ print_battery_remain() {
 			upower -i $battery | grep -E '(remain|time to empty)' | awk '{print $(NF-1)}'
 		fi
 	elif command_exists "acpi"; then
-		acpi -b | grep -Eo "[0-9]+:[0-9]+:[0-9]+"
+		acpi -b | grep -m 1 -Eo "[0-9]+:[0-9]+:[0-9]+"
 	fi
 }
 
@@ -66,7 +66,7 @@ print_battery_full() {
 	if command_exists "pmset"; then
 		pmset_battery_remaining_time
 	elif command_exists "upower"; then
-		battery=$(upower -e | grep battery | head -1)
+		battery=$(upower -e | grep -m 1 battery)
 		upower -i $battery | grep 'time to full' | awk '{printf "- %s %s till full", $4, $5}'
 	fi
 }

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -31,11 +31,10 @@ battery_status() {
 	if command_exists "pmset"; then
 		pmset -g batt | awk -F '; *' 'NR==2 { print $2 }'
 	elif command_exists "upower"; then
-		# sort order: attached, charging, discharging
-		for battery in $(upower -e | grep battery); do
-			upower -i $battery | grep state | awk '{print $2}'
-		done | sort | head -1
+		local battery
+		battery=$(upower -e | grep -m 1 battery)
+		upower -i $battery | awk '/state/ {print $2}'
 	elif command_exists "acpi"; then
-		acpi -b | grep -oi 'discharging' | awk '{print tolower($0)}'
+		acpi -b | awk '{gsub(/,/, ""); print tolower($3); exit}'
 	fi
 }


### PR DESCRIPTION
I have a bluetooth mouse that `upower` correctly detects as a battery device. Having it connected made my battery indicator disappear.

```bash
upower -e | grep battery 
/org/freedesktop/UPower/devices/battery_BAT0
/org/freedesktop/UPower/devices/mouse_hid_34o88o5do5do50of8_battery
```

This effectively always uses the **first battery** for the percentage, icon etc.

Bonus: This also fixes the `battery_status` when using acpi. Previously the state would only be set if the battery was discharging.