### PR TITLE
Assume no battery percentage as ok, assume it might be a desktop

### DIFF
--- a/scripts/battery_status_bg.sh
+++ b/scripts/battery_status_bg.sh
@@ -30,6 +30,8 @@ print_battery_status_bg() {
         printf $color_high_charge
     elif [ $percentage -le 50 -a $percentage -ge 16 ];then
         printf $color_medium_charge
+    elif [ "$percentage" == "" ];then  
+        printf $color_full_charge_default  # assume it's a desktop
     else
         printf $color_low_charge
     fi

--- a/scripts/battery_status_fg.sh
+++ b/scripts/battery_status_fg.sh
@@ -30,6 +30,8 @@ print_battery_status_fg() {
         printf $color_high_charge
     elif [ $percentage -le 50 -a $percentage -ge 16 ];then
         printf $color_medium_charge
+    elif [ "$percentage" == "" ];then  
+        printf $color_full_charge_default  # assume it's a desktop
     else
         printf $color_low_charge
     fi


### PR DESCRIPTION
Sharing same programming (via common .dotfiles) environment on desktop as on laptop results in having red alert from tmux-battery.
For me `upower -e` has result of only `/org/freedesktop/UPower/devices/DisplayDevice` and not giving any battery information. Anyway, battery_percentage gives back empty string in case and this PR will just assume, it's ok and not turn fg and bg colors to low_charge.

But of course, with no battery at any all, fg_color and bg_color should look same as full charged what they will after this PR merged. There's a still a difference to a loaded laptop, as there is no charged icon, what also is what it looks like.