### PR TITLE
Use battery percentage icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,10 +90,10 @@ following lines are not in the code block so that emojis can be seen):
  - set -g @batt_charging_icon ":+1:"
  - set -g @batt_discharging_icon ":thumbsdown:"
  - set -g @batt_attached_icon ":neutral_face:"
- - set -g @full_charge_icon "🌕 "
- - set -g @high_charge_icon "🌖 "
- - set -g @medium_charge_icon "🌗 "
- - set -g @low_charge_icon "🌘 "
+ - set -g @batt_full_charge_icon "🌕 "
+ - set -g @batt_high_charge_icon "🌖 "
+ - set -g @batt_medium_charge_icon "🌗 "
+ - set -g @batt_low_charge_icon "🌘 "
 
 Don't forget to reload tmux environment (`$ tmux source-file ~/.tmux.conf`)
 after you do this.

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ By default, these icons are displayed:
 
  - charged: ":battery:" ("❇ " when not on OS X)
  - charging: ":zap:"
- - discharging: (nothing shown)
+ - discharging: Moon icons depending on your battery level
  - attached but not charging: ":warning:"
 
 You can change these defaults by adding the following to `.tmux.conf` (the
@@ -90,6 +90,10 @@ following lines are not in the code block so that emojis can be seen):
  - set -g @batt_charging_icon ":+1:"
  - set -g @batt_discharging_icon ":thumbsdown:"
  - set -g @batt_attached_icon ":neutral_face:"
+ - set -g @full_charge_icon "🌕 "
+ - set -g @high_charge_icon "🌖 "
+ - set -g @medium_charge_icon "🌗 "
+ - set -g @low_charge_icon "🌘 "
 
 Don't forget to reload tmux environment (`$ tmux source-file ~/.tmux.conf`)
 after you do this.

--- a/scripts/battery_icon.sh
+++ b/scripts/battery_icon.sh
@@ -8,13 +8,20 @@ source "$CURRENT_DIR/helpers.sh"
 charged_icon=""
 charging_icon=""
 attached_icon=""
-discharging_icon=""
+# discharging_icon=""
+full_charge_icon=""
+high_charge_icon=""
+medium_charge_icon=""
+low_charge_icon=""
 
 charged_default="❇ "
 charged_default_osx="🔋 "
 charging_default="⚡️ "
 attached_default="⚠️ "
-discharging_default=""
+full_charge_icon_default="🌕 "
+high_charge_icon_default="🌖 "
+medium_charge_icon_default="🌗 "
+low_charge_icon_default="🌘 "
 
 charged_default() {
 	if is_osx; then
@@ -29,7 +36,10 @@ get_icon_settings() {
 	charged_icon=$(get_tmux_option "@batt_charged_icon" "$(charged_default)")
 	charging_icon=$(get_tmux_option "@batt_charging_icon" "$charging_default")
 	attached_icon=$(get_tmux_option "@batt_attached_icon" "$attached_default")
-	discharging_icon=$(get_tmux_option "@batt_discharging_icon" "$discharging_default")
+    full_charge_icon=$(get_tmux_option "@batt_full_charge_icon" "$full_charge_icon_default")
+    high_charge_icon=$(get_tmux_option "@batt_high_charge_icon" "$high_charge_icon_default")
+    medium_charge_icon=$(get_tmux_option "@batt_medium_charge_icon" "$medium_charge_icon_default")
+    low_charge_icon=$(get_tmux_option "@batt_low_charge_icon" "$low_charge_icon_default")
 }
 
 print_icon() {
@@ -39,7 +49,19 @@ print_icon() {
 	elif [[ $status =~ (^charging) ]]; then
 		printf "$charging_icon"
 	elif [[ $status =~ (^discharging) ]]; then
-		printf "$discharging_icon"
+        # use code from the bg color
+        percentage=$($CURRENT_DIR/battery_percentage.sh | sed -e 's/%//')
+        if [ $percentage -eq 100 ]; then
+            printf $full_charge_icon
+        elif [ $percentage -le 99 -a $percentage -ge 51 ];then
+            printf $high_charge_icon
+        elif [ $percentage -le 50 -a $percentage -ge 16 ];then
+            printf $medium_charge_icon
+        elif [ "$percentage" == "" ];then  
+            printf $full_charge_icon_default  # assume it's a desktop
+        else
+            printf $low_charge_icon
+        fi
 	elif [[ $status =~ (attached) ]]; then
 		printf "$attached_icon"
 	fi


### PR DESCRIPTION
Instead of having a single icon for when your battery is discharging, use multiple icons that change at the same levels as the background.