### PR TITLE
Allow to put colors in discharging icons

### DIFF
--- a/scripts/battery_icon.sh
+++ b/scripts/battery_icon.sh
@@ -36,10 +36,10 @@ get_icon_settings() {
 	charged_icon=$(get_tmux_option "@batt_charged_icon" "$(charged_default)")
 	charging_icon=$(get_tmux_option "@batt_charging_icon" "$charging_default")
 	attached_icon=$(get_tmux_option "@batt_attached_icon" "$attached_default")
-    full_charge_icon=$(get_tmux_option "@batt_full_charge_icon" "$full_charge_icon_default")
-    high_charge_icon=$(get_tmux_option "@batt_high_charge_icon" "$high_charge_icon_default")
-    medium_charge_icon=$(get_tmux_option "@batt_medium_charge_icon" "$medium_charge_icon_default")
-    low_charge_icon=$(get_tmux_option "@batt_low_charge_icon" "$low_charge_icon_default")
+	full_charge_icon=$(get_tmux_option "@batt_full_charge_icon" "$full_charge_icon_default")
+	high_charge_icon=$(get_tmux_option "@batt_high_charge_icon" "$high_charge_icon_default")
+	medium_charge_icon=$(get_tmux_option "@batt_medium_charge_icon" "$medium_charge_icon_default")
+	low_charge_icon=$(get_tmux_option "@batt_low_charge_icon" "$low_charge_icon_default")
 }
 
 print_icon() {
@@ -52,15 +52,15 @@ print_icon() {
         # use code from the bg color
         percentage=$($CURRENT_DIR/battery_percentage.sh | sed -e 's/%//')
         if [ $percentage -eq 100 ]; then
-            printf $full_charge_icon
+            printf "$full_charge_icon"
         elif [ $percentage -le 99 -a $percentage -ge 51 ];then
-            printf $high_charge_icon
+            printf "$high_charge_icon"
         elif [ $percentage -le 50 -a $percentage -ge 16 ];then
-            printf $medium_charge_icon
+            printf "$medium_charge_icon"
         elif [ "$percentage" == "" ];then  
-            printf $full_charge_icon_default  # assume it's a desktop
+            printf "$full_charge_icon_default"  # assume it's a desktop
         else
-            printf $low_charge_icon
+            printf "$low_charge_icon"
         fi
 	elif [[ $status =~ (attached) ]]; then
 		printf "$attached_icon"


### PR DESCRIPTION
I'm using character as icons and I want to put colors around the icon depending on the status.
It wasn't working, so I fixed it...

My config:

```
set -g @batt_full_charge_icon "#[fg=green] test#[fg=default]"
set -g @batt_high_charge_icon "#[fg=yellow] test#[fg=default]"
set -g @batt_medium_charge_icon "#[fg=orange] test#[fg=default]"
set -g @batt_low_charge_icon "#[fg=red] test#[fg=default]"
```