### PR TITLE
termux initial support

### DIFF
--- a/scripts/battery_percentage.sh
+++ b/scripts/battery_percentage.sh
@@ -22,6 +22,8 @@ print_battery_percentage() {
 		fi
 	elif command_exists "acpi"; then
 		acpi -b | grep -m 1 -Eo "[0-9]+%"
+	elif command_exists "termux-battery-status"; then
+		termux-battery-status | jq -r '.percentage' | awk '{printf("%d%%", $1)}'
 	fi
 }
 

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -36,5 +36,7 @@ battery_status() {
 		upower -i $battery | awk '/state/ {print $2}'
 	elif command_exists "acpi"; then
 		acpi -b | awk '{gsub(/,/, ""); print tolower($3); exit}'
+	elif command_exists "termux-battery-status"; then
+		termux-battery-status | jq -r '.status' | awk '{printf("%s%", tolower($1))}'
 	fi
 }


### PR DESCRIPTION
requires jq and awk

termux returns chrome os battery info via a json blob like this:

```
{
  "health": "UNKNOWN",
  "percentage": 100,
  "plugged": "PLUGGED_AC",
  "status": "CHARGING",
  "temperature": 0.0
}
```

you'll also need to run `termux-fix-shebang` against `battery.tmux` and `scripts/*.sh`