### PR TITLE
Add dependencies to the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,13 @@
 Enables displaying battery percentage and status icon in tmux status-right.
 
 ## Installation
+
+In order to read the battery status, this plugin depends on having either one of the following installed:
+- pmset
+- upower
+- acpi
+- termux-battery-status
+
 ### Installation with [Tmux Plugin Manager](https://github.com/tmux-plugins/tpm) (recommended)
 
 Add plugin to the list of TPM plugins in `.tmux.conf`:


### PR DESCRIPTION
I just tried this plugin but it did not seem to work.
After having a look at the source I figured this plugin relied on one of several commands being available.
Once one of them was installed, every thing went fine.