### PR TITLE
Use DisplayDevice if available

### DIFF
--- a/scripts/battery_percentage.sh
+++ b/scripts/battery_percentage.sh
@@ -9,7 +9,8 @@ print_battery_percentage() {
 	if command_exists "pmset"; then
 		pmset -g batt | grep -o "[0-9]\{1,3\}%"
 	elif command_exists "upower"; then
-		local battery=$(upower -e | grep -m 1 battery)
+        # use DisplayDevice if available otherwise battery
+		local battery=$(upower -e | grep -E 'battery|DisplayDevice'| tail -n1)
 		if [ -z "$battery" ]; then
 			return
 		fi

--- a/scripts/battery_remain.sh
+++ b/scripts/battery_remain.sh
@@ -43,7 +43,7 @@ print_battery_remain() {
 	if command_exists "pmset"; then
 		pmset_battery_remaining_time
 	elif command_exists "upower"; then
-		battery=$(upower -e | grep -m 1 battery)
+		battery=$(upower -e | grep -E 'battery|DisplayDevice'| tail -n1)
 		if is_chrome; then
 			if battery_discharging; then
 				upower -i $battery | grep 'time to empty' | awk '{printf "- %s %s left", $4, $5}'
@@ -66,7 +66,7 @@ print_battery_full() {
 	if command_exists "pmset"; then
 		pmset_battery_remaining_time
 	elif command_exists "upower"; then
-		battery=$(upower -e | grep -m 1 battery)
+		battery=$(upower -e | grep -E 'battery|DisplayDevice'| tail -n1)
 		upower -i $battery | grep 'time to full' | awk '{printf "- %s %s till full", $4, $5}'
 	fi
 }

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -32,7 +32,7 @@ battery_status() {
 		pmset -g batt | awk -F '; *' 'NR==2 { print $2 }'
 	elif command_exists "upower"; then
 		local battery
-		battery=$(upower -e | grep -m 1 battery)
+		battery=$(upower -e | grep -E 'battery|DisplayDevice'| tail -n1)
 		upower -i $battery | awk '/state/ {print $2}'
 	elif command_exists "acpi"; then
 		acpi -b | awk '{gsub(/,/, ""); print tolower($3); exit}'


### PR DESCRIPTION
  For laptops with multiple batteries, DisplayDevice should be
  available, otherwise stick to the old behaviour.

  See https://upower.freedesktop.org/docs/UPower.html#id-1.2.3.8.5