### PR TITLE
fix time to charge display on mac, issue #28

### DIFF
--- a/scripts/battery_remain.sh
+++ b/scripts/battery_remain.sh
@@ -15,6 +15,11 @@ battery_discharging() {
 	[[ $status =~ (discharging) ]]
 }
 
+battery_charged() {
+	local status="$(battery_status)"
+	[[ $status =~ (charged) ]]
+}
+
 pmset_battery_remaining_time() {
 	local status="$(pmset -g batt)"
 	if echo $status | grep 'no estimate' >/dev/null 2>&1; then
@@ -30,6 +35,12 @@ pmset_battery_remaining_time() {
 				echo $remaining_time | awk '{printf "~%s", $1}'
 			else
 				echo $remaining_time | awk '{printf "- %s left", $1}'
+			fi
+		elif battery_charged; then
+			if $short; then
+				echo $remaining_time | awk '{printf "charged", $1}'
+			else
+				echo $remaining_time | awk '{printf "fully charged", $1}'
 			fi
 		else
 			if $short; then

--- a/scripts/battery_remain.sh
+++ b/scripts/battery_remain.sh
@@ -32,7 +32,9 @@ pmset_battery_remaining_time() {
 				echo $remaining_time | awk '{printf "- %s left", $1}'
 			fi
 		else
-			if !$short; then
+			if $short; then
+				echo $remaining_time | awk '{printf "~%s", $1}'
+			else
 				echo $remaining_time | awk '{printf "- %s till full", $1}'
 			fi
 		fi
@@ -76,9 +78,7 @@ main() {
 	if battery_discharging; then
 		print_battery_remain
 	else
-		if !$short; then
-			print_battery_full
-		fi
+		print_battery_full
 	fi
 }
 main

--- a/scripts/battery_status_fg.sh
+++ b/scripts/battery_status_fg.sh
@@ -8,23 +8,29 @@ color_full_charge_default="#[fg=green]"
 color_high_charge_default="#[fg=yellow]"
 color_medium_charge_default="#[fg=colour208]" # orange
 color_low_charge_default="#[fg=red]"
+color_charging_default="#[fg=blue]"
 
 color_full_charge=""
 color_high_charge=""
 color_medium_charge=""
 color_low_charge=""
+color_charging=""
 
 get_charge_color_settings() {
     color_full_charge=$(get_tmux_option "@batt_color_full_charge" "$color_full_charge_default")
     color_high_charge=$(get_tmux_option "@batt_color_high_charge" "$color_high_charge_default")
     color_medium_charge=$(get_tmux_option "@batt_color_medium_charge" "$color_medium_charge_default")
     color_low_charge=$(get_tmux_option "@batt_color_low_charge" "$color_low_charge_default")
+    color_charging=$(get_tmux_option "@batt_color_charging" "$color_charging_default")
 }
 
 print_battery_status_fg() {
+    status=$(battery_status | awk '{print $1;}')
+    if [ $status == 'charging' ]; then
+        printf $color_charging
     # Call `battery_percentage.sh`.
     percentage=$($CURRENT_DIR/battery_percentage.sh | sed -e 's/%//')
-    if [ $percentage -eq 100 ]; then
+    elif [ $percentage -eq 100 ]; then
         printf $color_full_charge
     elif [ $percentage -le 99 -a $percentage -ge 51 ];then
         printf $color_high_charge

--- a/scripts/battery_status_fg.sh
+++ b/scripts/battery_status_fg.sh
@@ -8,7 +8,7 @@ color_full_charge_default="#[fg=green]"
 color_high_charge_default="#[fg=yellow]"
 color_medium_charge_default="#[fg=colour208]" # orange
 color_low_charge_default="#[fg=red]"
-color_charging_default="#[fg=blue]"
+color_charging_default="#[fg=green]"
 
 color_full_charge=""
 color_high_charge=""

--- a/scripts/battery_status_fg.sh
+++ b/scripts/battery_status_fg.sh
@@ -25,11 +25,11 @@ get_charge_color_settings() {
 }
 
 print_battery_status_fg() {
+    # Call `battery_percentage.sh`.
+    percentage=$($CURRENT_DIR/battery_percentage.sh | sed -e 's/%//')
     status=$(battery_status | awk '{print $1;}')
     if [ $status == 'charging' ]; then
         printf $color_charging
-    # Call `battery_percentage.sh`.
-    percentage=$($CURRENT_DIR/battery_percentage.sh | sed -e 's/%//')
     elif [ $percentage -eq 100 ]; then
         printf $color_full_charge
     elif [ $percentage -le 99 -a $percentage -ge 51 ];then


### PR DESCRIPTION
Time to charge display wasn't working either with the short or long format. I've tested it with High Sierra and the changes are quite minimal.