### PR TITLE
Fix batt_remain_short behavior when using upower.

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,7 @@ To shorten the output of `#{battery_remain}`, set the following variable:
 
     set -g @batt_remain_short true
 
-This will hide output if the battery is charging or charged, and shorten the
-time remaining (when discharging) to `~H:MM`.
+This will shorten the time remaining (when charging or discharging) to `~H:MM`.
 
 ### Tmux Plugins
 
@@ -134,6 +133,7 @@ twitter if you want to hear about new tmux plugins or feature updates.
  - Aleksandar Djurdjic
  - Bruno Sutic
  - Caleb
+ - Diego Ximenes
  - Evan N-D
  - Jan Ahrens
  - Joey Geralnik

--- a/scripts/battery_remain.sh
+++ b/scripts/battery_remain.sh
@@ -52,44 +52,49 @@ pmset_battery_remaining_time() {
 	fi
 }
 
+upower_battery_remaining_time() {
+	battery=$(upower -e | grep -E 'battery|DisplayDevice'| tail -n1)
+	if battery_discharging; then
+		local remaining_time
+		remaining_time=$(upower -i "$battery" | grep -E '(remain|time to empty)')
+		if $short; then
+			echo "$remaining_time" | awk '{printf "%s %s", $(NF-1), $(NF)}'
+		else
+			echo "$remaining_time" | awk '{printf "%s %s left", $(NF-1), $(NF)}'
+		fi
+	elif battery_charged; then
+		if $short; then
+			echo ""
+		else
+			echo "charged"
+		fi
+	else
+		local remaining_time
+		remaining_time=$(upower -i "$battery" | grep -E 'time to full')
+		if $short; then
+			echo "$remaining_time" | awk '{printf "%s %s", $(NF-1), $(NF)}'
+		else
+			echo "$remaining_time" | awk '{printf "%s %s to full", $(NF-1), $(NF)}'
+		fi
+	fi
+}
+
+acpi_battery_remaining_time() {
+	acpi -b | grep -m 1 -Eo "[0-9]+:[0-9]+:[0-9]+"
+}
+
 print_battery_remain() {
 	if command_exists "pmset"; then
 		pmset_battery_remaining_time
 	elif command_exists "upower"; then
-		battery=$(upower -e | grep -E 'battery|DisplayDevice'| tail -n1)
-		if is_chrome; then
-			if battery_discharging; then
-				upower -i $battery | grep 'time to empty' | awk '{printf "- %s %s left", $4, $5}'
-			else
-				upower -i $battery | grep 'time to full' | awk '{printf "- %s %s till full", $4, $5}'
-			fi
-		else
-			upower -i $battery | grep -E '(remain|time to empty)' | awk '{print $(NF-1)}'
-		fi
+		upower_battery_remaining_time
 	elif command_exists "acpi"; then
-		acpi -b | grep -m 1 -Eo "[0-9]+:[0-9]+:[0-9]+"
-	fi
-}
-
-print_battery_full() {
-	if !$short; then
-		return
-	fi
-
-	if command_exists "pmset"; then
-		pmset_battery_remaining_time
-	elif command_exists "upower"; then
-		battery=$(upower -e | grep -E 'battery|DisplayDevice'| tail -n1)
-		upower -i $battery | grep 'time to full' | awk '{printf "- %s %s till full", $4, $5}'
+		acpi_battery_remaining_time
 	fi
 }
 
 main() {
 	get_remain_settings
-	if battery_discharging; then
-		print_battery_remain
-	else
-		print_battery_full
-	fi
+	print_battery_remain
 }
 main


### PR DESCRIPTION
Fix behavior of `batt_remain_short` when using `upower`.