### PR TITLE
If upower reports a percentage, just use that

### DIFF
--- a/scripts/battery_percentage.sh
+++ b/scripts/battery_percentage.sh
@@ -14,6 +14,11 @@ print_battery_percentage() {
 		if [ -z "$battery" ]; then
 			return
 		fi
+		local percentage=$(upower -i $battery | awk '/percentage:/ {print $2}')
+		if [ "$percentage" ]; then
+			echo $percentage
+			return
+		fi
 		local energy
 		local energy_full
 		energy=$(upower -i $battery | awk -v nrg="$energy" '/energy:/ {print nrg+$2}')


### PR DESCRIPTION
I have a device (Gemini PDA) whose energy and energy-full are both zero, but the percentage is correct so just use that.  Upower probably knows best.  Probably also fixes #65.