### PR TITLE
Fix battery percentage output when using upower

### DIFF
--- a/scripts/battery_percentage.sh
+++ b/scripts/battery_percentage.sh
@@ -18,7 +18,7 @@ print_battery_percentage() {
 		fi
 		local percentage=$(upower -i $battery | awk '/percentage:/ {print $2}')
 		if [ "$percentage" ]; then
-			echo ${percentage%.*%}
+			echo "$(float2int $percentage)%"
 			return
 		fi
 		local energy

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -48,3 +48,14 @@ battery_status() {
 		fi
 	fi
 }
+
+float2int() {
+	local float="$1"
+	if [[ $float =~ "," ]]; then
+		echo ${float%,*}
+	elif [[ $float =~ "." ]]; then
+		echo ${float%.*}
+	else
+		echo ${float//%}
+	fi
+}


### PR DESCRIPTION
Upower output was 98.4789% which mess up the icon and graph view as
well.