### PR TITLE
Fix MacOSX Catalina without battery situation

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -29,7 +29,7 @@ command_exists() {
 
 battery_status() {
 	if command_exists "pmset"; then
-		RES=`pmset -g batt | awk -F '; *' 'NR==2 { print $2 }'`
+		RES=$(pmset -g batt | awk -F '; *' 'NR==2 { print $2 }')
 		if [ -z "$RES" ]; then
 			echo "charged"
 		else

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -30,11 +30,11 @@ command_exists() {
 battery_status() {
 	if command_exists "pmset"; then
 		RES=`pmset -g batt | awk -F '; *' 'NR==2 { print $2 }'`
-        if [ "$RES" = "" ];then
-            echo "charged"
-        else
-            echo "$RES"
-        fi
+		if [ -z "$RES" ]; then
+			echo "charged"
+		else
+			echo "$RES"
+		fi
 	elif command_exists "acpi"; then
 		acpi -b | awk '{gsub(/,/, ""); print tolower($3); exit}'
 	elif command_exists "upower"; then

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -31,7 +31,7 @@ battery_status() {
 	if command_exists "pmset"; then
 		RES=`pmset -g batt | awk -F '; *' 'NR==2 { print $2 }'`
         if [ "$RES" = "" ];then
-            echo "Now drawing from 'AC Power'\n-InternalBattery-0 100%; charged; 0:00 remaining"
+            echo "charged"
         else
             echo "$RES"
         fi

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -29,7 +29,12 @@ command_exists() {
 
 battery_status() {
 	if command_exists "pmset"; then
-		pmset -g batt | awk -F '; *' 'NR==2 { print $2 }'
+		RES=`pmset -g batt | awk -F '; *' 'NR==2 { print $2 }'`
+        if [ "$RES" = "" ];then
+            echo "Now drawing from 'AC Power'\n-InternalBattery-0 100%; charged; 0:00 remaining"
+        else
+            echo "$RES"
+        fi
 	elif command_exists "acpi"; then
 		acpi -b | awk '{gsub(/,/, ""); print tolower($3); exit}'
 	elif command_exists "upower"; then


### PR DESCRIPTION
- Situation
```zsh
✗ pmset -g batt
Now drawing from 'AC Power'
```
When I use `pmset` command using in helpers.sh, I get above output.My PC
does not have battery, so the plugin cannot display it well.
So I add some judgment for supporting the PC without battery.

Signed-off-by: van <yuzetao@chafou.com>