### PR TITLE
Added support for WSL

### DIFF
--- a/scripts/battery_percentage.sh
+++ b/scripts/battery_percentage.sh
@@ -6,7 +6,9 @@ source "$CURRENT_DIR/helpers.sh"
 
 print_battery_percentage() {
 	# percentage displayed in the 2nd field of the 2nd row
-	if command_exists "pmset"; then
+	if is_wsl; then
+		cat /sys/class/power_supply/battery/capacity
+	elif command_exists "pmset"; then
 		pmset -g batt | grep -o "[0-9]\{1,3\}%"
 	elif command_exists "acpi"; then
 		acpi -b | grep -m 1 -Eo "[0-9]+%"

--- a/scripts/battery_remain.sh
+++ b/scripts/battery_remain.sh
@@ -17,7 +17,7 @@ battery_discharging() {
 
 battery_charged() {
 	local status="$(battery_status)"
-	[[ $status =~ (charged) ]]
+	[[ $status =~ (charged) || $status =~ (full) ]]
 }
 
 

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -22,13 +22,24 @@ is_chrome() {
 	fi
 }
 
+is_wsl() {
+	version=$(</proc/version)
+	if [[ "$version" == *"Microsoft"* ]]; then
+		return 0
+	else
+		return 1
+	fi
+}
+
 command_exists() {
 	local command="$1"
 	type "$command" >/dev/null 2>&1
 }
 
 battery_status() {
-	if command_exists "pmset"; then
+	if is_wsl; then
+		cat /sys/class/power_supply/battery/status | awk '{print tolower($0);}'
+	elif command_exists "pmset"; then
 		pmset -g batt | awk -F '; *' 'NR==2 { print $2 }'
 	elif command_exists "acpi"; then
 		acpi -b | awk '{gsub(/,/, ""); print tolower($3); exit}'


### PR DESCRIPTION
Battery status in WSL couldn't be retrieved by the utilities used in tmux-battery.
Fetched the params directly from `/sys/class/power_supply/battery/` for WSL systems

Closes https://github.com/tmux-plugins/tmux-battery/issues/86