### PR TITLE
Add option to hide the battery percentage if above user-defined threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,11 +78,16 @@ set -g status-right '#{battery_status_bg} Batt: #{battery_icon} #{battery_percen
 
  - `@batt_remain_short`: 'true' / 'false' - This will shorten the time remaining (when charging or discharging) to `~H:MM`.
 
+`#{battery_percentage}`
+
+ - `@batt_percentage_hide_if_above`: integer (`[0-100]`) - Hides the battery percentage indicator if the battery level is above this threshold.
+
 ### Defaults
 
 #### Options
 
  - `@batt_remain_short`: 'false'
+ - `@batt_percentage_hide_if_above`: '' (always display battery percentage)
 
 #### Icons/Colors
 

--- a/scripts/battery_percentage.sh
+++ b/scripts/battery_percentage.sh
@@ -36,6 +36,25 @@ print_battery_percentage() {
 }
 
 main() {
-	print_battery_percentage
+	local bat_pct
+	local bat_pct_raw
+
+	bat_pct_raw="$(print_battery_percentage)"
+	bat_pct="${bat_pct_raw//%/}"
+
+	if ! [[ "$bat_pct" =~ ^[0-9]+$ ]]
+	then
+		# Display bat percentage string if not a number
+		echo -n "$bat_pct_raw"
+		return
+	fi
+
+	local hide_if_above
+	hide_if_above="$(get_tmux_option "@batt_percentage_hide_if_above")"
+
+	if [[ "$bat_pct" -lt "${hide_if_above}" ]]
+	then
+		echo -n "$bat_pct_raw"
+	fi
 }
 main


### PR DESCRIPTION
This introduces a new config option to hide the battery percentage indicator if the current battery level is above it.

Example:

```tmux
set -g @batt_percentage_hide_if_above 90
```

👆 would hide `#{battery_percentage}` if the battery level is > 90.