### PR TITLE
Add support for WSL2 and for alternate powersupply names

### DIFF
--- a/scripts/battery_percentage.sh
+++ b/scripts/battery_percentage.sh
@@ -7,7 +7,9 @@ source "$CURRENT_DIR/helpers.sh"
 print_battery_percentage() {
 	# percentage displayed in the 2nd field of the 2nd row
 	if is_wsl; then
-		cat /sys/class/power_supply/battery/capacity
+		local battery
+		battery=$(find /sys/class/power_supply/*/capacity | tail -n1)
+		cat "$battery"
 	elif command_exists "pmset"; then
 		pmset -g batt | grep -o "[0-9]\{1,3\}%"
 	elif command_exists "acpi"; then

--- a/scripts/battery_remain.sh
+++ b/scripts/battery_remain.sh
@@ -110,7 +110,9 @@ acpi_battery_remaining_time() {
 }
 
 print_battery_remain() {
-	if command_exists "pmset"; then
+	if is_wsl; then
+		echo "?"	# currently unsupported on WSL
+	elif command_exists "pmset"; then
 		pmset_battery_remaining_time
 	elif command_exists "acpi"; then
 		acpi_battery_remaining_time

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -24,7 +24,7 @@ is_chrome() {
 
 is_wsl() {
 	version=$(</proc/version)
-	if [[ "$version" == *"Microsoft"* ]]; then
+	if [[ "$version" == *"Microsoft"* || "$version" == *"microsoft"* ]]; then
 		return 0
 	else
 		return 1
@@ -38,7 +38,9 @@ command_exists() {
 
 battery_status() {
 	if is_wsl; then
-		cat /sys/class/power_supply/battery/status | awk '{print tolower($0);}'
+		local battery
+		battery=$(find /sys/class/power_supply/*/status | tail -n1)
+		awk '{print tolower($0);}' "$battery"
 	elif command_exists "pmset"; then
 		pmset -g batt | awk -F '; *' 'NR==2 { print $2 }'
 	elif command_exists "acpi"; then


### PR DESCRIPTION
This fixes the following issues with #95:

- WSL2 may not be recognized due to "microsoft" appearing lowercase in `/proc/version`
- Battery percentage and status are not fetched if the power_supply name is not `battery`