### PR TITLE
Fix Battery Percentage When Grep Colors Is Set(Zsh)

### DIFF
--- a/scripts/battery_percentage.sh
+++ b/scripts/battery_percentage.sh
@@ -11,7 +11,7 @@ print_battery_percentage() {
 		battery=$(find /sys/class/power_supply/*/capacity | tail -n1)
 		cat "$battery"
 	elif command_exists "pmset"; then
-		pmset -g batt | grep -o "[0-9]\{1,3\}%"
+		pmset -g batt | grep --color=never -o "[0-9]\{1,3\}%"
 	elif command_exists "acpi"; then
 		acpi -b | grep -m 1 -Eo "[0-9]+%"
 	elif command_exists "upower"; then

--- a/scripts/battery_percentage.sh
+++ b/scripts/battery_percentage.sh
@@ -13,7 +13,7 @@ print_battery_percentage() {
 	elif command_exists "pmset"; then
 		pmset -g batt | grep --color=never -o "[0-9]\{1,3\}%"
 	elif command_exists "acpi"; then
-		acpi -b | grep -m 1 -Eo "[0-9]+%"
+		acpi -b | grep --color=never -m 1 -Eo "[0-9]+%"
 	elif command_exists "upower"; then
         # use DisplayDevice if available otherwise battery
 		local battery=$(upower -e | grep -E 'battery|DisplayDevice'| tail -n1)


### PR DESCRIPTION
When switching from bash to zsh on my Macbook the `battery_percentage` output went from the normal `%100` to `[1;35;40m[K100%[m[K` after messing with it for a while I realized I had set `GREP_OPTIONS='--color=always'` in my `.zshrc` file and zsh was setting that env var in the script being used to output the battery_percentage.  So the output was being wrapped in grep colorization.

This PR fixes the issue with grep attempting to colorize output for pmset by passing the option --color=never to the grep command in the battery percentage script.

*I realize that grep is used in many other places in this plugin but I don't have the resources to test all the other uses it's used at and am worried about breaking something by copying the change to all uses of grep without testing each one.