### PR TITLE
Use `echo` and Append Percentage Symbol on WSL

### DIFF
--- a/scripts/battery_percentage.sh
+++ b/scripts/battery_percentage.sh
@@ -7,9 +7,11 @@ source "$CURRENT_DIR/helpers.sh"
 print_battery_percentage() {
 	# percentage displayed in the 2nd field of the 2nd row
 	if is_wsl; then
-		local battery
-		battery=$(find /sys/class/power_supply/*/capacity | tail -n1)
-		cat "$battery"
+		local battery=$(find /sys/class/power_supply/*/capacity | tail -n1)
+		if [ -n "$battery" ]; then
+			echo $(cat "$battery")%
+			return
+		fi
 	elif command_exists "pmset"; then
 		pmset -g batt | grep -o "[0-9]\{1,3\}%"
 	elif command_exists "acpi"; then


### PR DESCRIPTION
Instead of straightforwardly calling `cat`, I've encased the command in `echo` to enable appending strings. This allows me to add a percentage symbol after calling `cat "$battery"`, like with other battery-related tools.

This also suppresses any `echo`s for machines without battery (i.e. a desktop environment)