### PR TITLE
add mac charging watts

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ set -g status-right '#{battery_status_bg} Batt: #{battery_icon} #{battery_percen
  - `#{battery_icon_status}` - will display a battery status icon
  - `#{battery_percentage}` - will show battery percentage
  - `#{battery_remain}` - will show remaining time of battery charge\*
+ = `#{battery_charging_watts}` - will display the current watts supplied (currently supported only on OSX)
 
 \* These format strings can be further customized via options as described below.
 

--- a/battery.tmux
+++ b/battery.tmux
@@ -17,6 +17,7 @@ battery_interpolation=(
 	"\#{battery_icon_status}"
 	"\#{battery_percentage}"
 	"\#{battery_remain}"
+	"\#{battery_charging_watts}"
 )
 
 battery_commands=(
@@ -32,6 +33,7 @@ battery_commands=(
 	"#($CURRENT_DIR/scripts/battery_icon_status.sh)"
 	"#($CURRENT_DIR/scripts/battery_percentage.sh)"
 	"#($CURRENT_DIR/scripts/battery_remain.sh)"
+	"#($CURRENT_DIR/scripts/battery_charging_watts.sh)"
 )
 
 set_tmux_option() {

--- a/scripts/battery_charging_watts.sh
+++ b/scripts/battery_charging_watts.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+source "$CURRENT_DIR/helpers.sh"
+
+print_battery_percentage() {
+	if is_osx; then
+		watts=$(system_profiler SPPowerDataType | grep Wattage | awk '{print $3}')
+		if [ -z $watts];
+		then
+		    watts="0"
+		fi
+		echo "$watts"
+	else 
+		echo "??"
+	fi
+}
+
+main() {
+	print_battery_percentage
+}
+main


### PR DESCRIPTION
add support for displaying the charging watts on osx via the `SPPowerDataType` tool



![image](https://github.com/tmux-plugins/tmux-battery/assets/4248857/15438da2-269c-44db-ba88-4b7118bf6c32)
