### PR TITLE
return appropriate icon for 'finishing charge'

### DIFF
--- a/scripts/battery_icon_status.sh
+++ b/scripts/battery_icon_status.sh
@@ -39,7 +39,7 @@ get_icon_status_settings() {
 
 print_icon_status() {
 	local status=$1
-	if [[ $status =~ (charged) || $status =~ (full) ]]; then
+	if [[ $status =~ (charged) || $status =~ (full) || $status =~ (^finishing charge) ]]; then
 		printf "$icon_status_charged"
 	elif [[ $status =~ (^charging) ]]; then
 		printf "$icon_status_charging"


### PR DESCRIPTION
`pmset` can return the status `finishing charge`, which currently gets evaluated as "unknown" in `tmux-battery`. 

[pmset source code](https://github.com/apple-oss-distributions/PowerManagement/blob/84de1dde1bcbfd48e18747da0a29f2f36b589755/pmset/pmset.m#L2344)
