### PR TITLE
feat: add battery_enabled script

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,17 @@ Status Icons:
  - attached (`@batt_icon_status_attached`): '⚠️'
  - unknown (`@batt_icon_status_unknown`): '?'
 
+#### Enabled
+
+If you run  `battery_enabled.tmux` from the top-level of the repo, it will setup a `@battery_enabled` variable, that can be used to selectively display the battery based on whether or not a battery is available or not.
+
+```tmux
+run-shell ~/clone/path/battery_enabled.tmux
+# for example, if using catppuccin:
+set -agF status-right "#{?#{#{==:#{E:@battery_exists},true}},#{E:@catppuccin_status_battery},}"
+run-shell ~/clone/path/battery.tmux
+```
+
 #### Changing the Defaults
 
 All efforts have been made to make sane defaults, but if you wish to change any of them, add the option to `.tmux.conf`. For example:

--- a/battery_enabled.tmux
+++ b/battery_enabled.tmux
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+source "$CURRENT_DIR/scripts/helpers.sh"
+
+main() {
+	tmux set-option -gq "@battery_exists" "$( [ -n "$(battery_status)" ] && echo true || echo false )"
+}
+main


### PR DESCRIPTION
Currently, there is no reliable way to determine whether or not a battery is available in the system, making this plugin less portable.
There was an older issue regarding this: https://github.com/tmux-plugins/tmux-battery/issues/63
The aim of this PR is to make it easier to determine whether a battery is available on the system by setting up a variable, `@battery_enabled` that will be `true` when a battery is detected, and `false` otherwise.
It needs to be included in a separate file, because if added via interpolation, it won't be possible to use along side other variables, such as `{E:@catppuccin_status_battery}` that have to be rendered via `set -F`.