### PR TITLE
Fix battery detection on systems with multiple ACPI batteries by filtering batteries with 0%

### DIFF
--- a/scripts/battery_percentage.sh
+++ b/scripts/battery_percentage.sh
@@ -9,7 +9,7 @@ print_battery_percentage() {
 	if command_exists "pmset"; then
 		pmset -g batt | grep -o "[0-9]\{1,3\}%"
 	elif command_exists "acpi"; then
-		acpi -b | grep -m 1 -Eo "[0-9]+%"
+		acpi -b | grep -v " 0%" | grep -m 1 -Eo "[0-9]+%"
 	elif command_exists "upower"; then
         # use DisplayDevice if available otherwise battery
 		local battery=$(upower -e | grep -E 'battery|DisplayDevice'| tail -n1)

--- a/scripts/battery_remain.sh
+++ b/scripts/battery_remain.sh
@@ -110,8 +110,9 @@ acpi_battery_remaining_time() {
 	if ! $short; then
 		regex="$regex:[0-9]+"
 	fi
-	acpi -b | grep -m 1 -Eo "$regex"
+	acpi -b | grep -v " 0%" | grep -m 1 -Eo "$regex"
 }
+
 
 print_battery_remain() {
 	if is_wsl; then


### PR DESCRIPTION
**Problem:**  
On many laptops with multiple ACPI-reported batteries (e.g., `Battery 0` and `Battery 1`), the current scripts incorrectly read the first battery’s status. Often, `Battery 0` is a phantom or inactive battery reporting `0%`, causing wrong battery percentage and remaining time displays.

**Solution:**  
This patch modifies the battery detection logic in the `tmux-battery` scripts to:

- Prefer the actual active battery (commonly `Battery 1`) by filtering out phantom batteries reporting `0%`.
- Update `acpi` command usage in all relevant scripts to ignore empty batteries.
- Improve robustness across different hardware configurations.

**Impact:**  
Users with laptops reporting multiple batteries will see accurate battery percentage and remaining time in tmux. This fix improves compatibility and usability significantly.
