### PR TITLE
fix: is_wsl() matches all Linux kernels, not just WSL

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -24,7 +24,7 @@ is_chrome() {
 
 is_wsl() {
 	version=$(</proc/version)
-	if [[ "$version" == *"Linux"* || "$version" == *"Microsoft"* || "$version" == *"microsoft"* ]]; then
+	if [[ "$version" == *"Microsoft"* || "$version" == *"microsoft"* ]]; then
 		return 0
 	else
 		return 1


### PR DESCRIPTION

## Summary

- `is_wsl()` in `helpers.sh` checks `/proc/version` for `"Linux"` OR `"Microsoft"` — but **every** Linux kernel starts with `"Linux version ..."`, so `is_wsl()` returns `true` on all Linux hosts, not just WSL
- This causes `battery_remain.sh` to take the WSL sysfs code path (reading `charge_full`/`charge_now`) instead of falling through to `upower`/`acpi`
- On systems without `acpi` installed, the WSL path **silently fails** with a division-by-zero error because modern kernels use `energy_full`/`energy_now` instead of `charge_full`/`charge_now`
- WSL kernels contain `"Microsoft"` or `"microsoft"` — native Linux kernels do not — so removing the `"Linux"` check correctly distinguishes them

## Test plan

- [ ] `is_wsl` returns `true` on WSL (`/proc/version` contains `"Microsoft"`)
- [ ] `is_wsl` returns `false` on native Linux (`/proc/version` contains `"Linux"` but not `"Microsoft"`)
- [ ] `battery_remain` correctly uses `upower` (or `acpi`/`pmset`/`apm`) on native Linux
- [ ] `battery_remain` still uses WSL sysfs path on actual WSL


💘 Generated with Crush